### PR TITLE
Feature/add lock to tooltips

### DIFF
--- a/tooltip/README.md
+++ b/tooltip/README.md
@@ -143,14 +143,20 @@ Now lets check out the public properties and methods available to you as the end
 ```javascript
   var instance = $(my-selector).data('mk-tooltip');
 ```
-###### **show( el, xy )**
+###### **show( trigger, xy )**
 Show a tooltip by passing in the trigger element. You can optionally pass in an object with x and y integers if you would like to manually position the tooltip yourself.
 
-###### **hide( el )**
+###### **hide( trigger )**
 Hide a tooltip by passing in the trigger element. If nothing is passed in, hideAll() is triggered.
 
 ###### **hideAll()**
 Hide all tooltips in a given delegate region.
+
+###### **lock( trigger )**
+Prevents a tooltip from hiding when mouseout or click until it is unlocked.
+
+###### **unlock( trigger )**
+Removes a tooltip's hiding lock.
 
 ##### Event Hooks
 All tooltip events are namespaced with *.mk-tooltip.* Currently, there are two possible event hooks you can use: **show** and **hide**. Let's take a look.

--- a/tooltip/mk-tooltip-1.0.0.js
+++ b/tooltip/mk-tooltip-1.0.0.js
@@ -19,7 +19,6 @@
 		},
 
 		_define: function () {
-
 			this._name = 'mk-tooltip';
 
 			this._templates = {
@@ -401,6 +400,24 @@
 				}
 			}
 		},
+		
+		lock: function (el, xy) {
+			var me = this,
+				$t = this._findTrigger(el),
+				$tip = this._findTooltip($t);
+			$tip.addClass('lock');
+			return this;
+
+		},
+		
+		unlock: function (el, xy) {
+			var me = this,
+				$t = this._findTrigger(el),
+				$tip = this._findTooltip($t);
+			$tip.removeClass('lock');
+			return this;
+	
+		},
 
 		show: function (el, xy) {
 
@@ -437,8 +454,10 @@
 
 			var $trigger = this._findTrigger(el),
 				$tip = this.aria($trigger).describedby(),
-				me = this;
-
+				me = this;				
+				
+			if ($tip.hasClass('lock')) { return; }
+			
 			this.clearTransitions($tip);
 			this.transition($tip, function () {
 				
@@ -460,6 +479,7 @@
 
 			var me = this;
 			this.$container.find(this._class('trigger', true)).each(function() {
+				if ( $(this).hasClass('lock') ) { return; }
 				me.hide(this);
 			});
 			return this;
@@ -477,3 +497,4 @@
 	};
 
 }(window.jQuery);
+


### PR DESCRIPTION
Allows a tooltip to be temporarily locked from being hidden by its associated hide event ('mouseout' or 'click').

My current use case is a tooltip appears when the trigger is clicked but shouldn't disappear until a button within the tooltip is clicked. On trigger, I lock() it and call show(). When the other button is clicked I unlock() it and hide() it.
