### PR TITLE
Add active dates option

### DIFF
--- a/datepicker/CHANGELOG.md
+++ b/datepicker/CHANGELOG.md
@@ -3,5 +3,8 @@ v1.0.1 - Bugfix in instance.refresh(), instance.day, instance.month, instance.ye
 v1.0.2 - Bugfix options.headerFormat was being referenced internally as headerformat (casing), preventing it from being correctly applied.
 
 v1.0.3 - Bugfix Move .day, .month, .year init from the _init method to the _buildOptions method. This allows the date to correctly update when calling buildOptions with a new initial: date. 
+
 v1.0.4 - Bugfix Correctly target caption when adding ID. Lets table's aria-labelledby point to
 caption. Previously was pointing to nothing.
+
+v1.1.0 - Add activeDates option.

--- a/datepicker/README.md
+++ b/datepicker/README.md
@@ -160,7 +160,8 @@ Below is the list of options available to provide via options object. Again, you
     headerFormat: string (weekday headers formatting),
     initial: string (as format) or Date,
     min: string (as format), Date, or selector,
-    max: string (as format), Date, or selector
+    max: string (as format), Date, or selector,
+	activeDates: Array<Date Objects> (applies active class to given dates) 
   }
 ```
 ##### Public API

--- a/datepicker/mk-datepicker.css
+++ b/datepicker/mk-datepicker.css
@@ -107,6 +107,11 @@
   -webkit-transition: all 0.3s;
 }
 
+.mk-datepicker-cell.active {
+	background: #ffc6c8;
+	color: #ffffff;
+}
+
 .mk-datepicker-cell.previous,
 .mk-datepicker-cell.next {
   background: #f7f7f7;

--- a/datepicker/mk-datepicker.js
+++ b/datepicker/mk-datepicker.js
@@ -1,5 +1,5 @@
 /// mk-datepicker ///
-/// v1.0.4       ///
+/// v1.1.0       ///
 
 !function($) {
 
@@ -192,6 +192,9 @@
 
 			var $max = this._nojq.test(o.max) ? null : $(o.max),
 				$min = this._nojq.test(o.min) ? null : $(o.min);
+
+			// active dates
+			o.activeDates = o.activeDates || [];
 
 			//jquery link
 			if ($max && $max.length) {
@@ -463,6 +466,7 @@
 		_buildCalendarDay: function(jsdate, date, day, isToday, previousMonth, nextMonth, disabled) {
 
 			var $day = this._template('day', {'day': date});
+			var active = this.options.activeDates.filter(function (date) { return +date == +jsdate; }).length; 
 
 			$day.addClass(this._class('cell'));
 
@@ -475,7 +479,9 @@
 			if (nextMonth) {
 				$day.addClass('next');
 			}
-
+			if (active) {
+				$day.addClass('active');	
+			}
 			if (disabled) {
 				this.aria($day).disabled();
 			}


### PR DESCRIPTION
Accepts an array of Date objects as the activeDates property on options. If calendar cell jsdate compares to one of the activeDates, that cell receives an "active" class.
